### PR TITLE
🐞 (napier): Rename substrate error

### DIFF
--- a/contracts/fuses/napier/NapierCollectFuse.sol
+++ b/contracts/fuses/napier/NapierCollectFuse.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.26;
 
-import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {PlasmaVaultConfigLib} from "../../libraries/PlasmaVaultConfigLib.sol";
 
 import {IPrincipalToken} from "./ext/IPrincipalToken.sol";
@@ -39,17 +38,19 @@ contract NapierCollectFuse is NapierUniversalRouterFuse {
 
     /// @notice Collects interest and external rewards if any
     function enter(NapierCollectFuseEnterData calldata data_) external {
-        if (!PlasmaVaultConfigLib.isSubstrateAsAssetGranted(MARKET_ID, address(data_.principalToken))) {
-            revert NapierFuseIInvalidMarketId();
+        IPrincipalToken principalToken = data_.principalToken;
+
+        if (!PlasmaVaultConfigLib.isSubstrateAsAssetGranted(MARKET_ID, address(principalToken))) {
+            revert NapierFuseIInvalidToken();
         }
 
         // Collect interest (in units of the underlying token) and external rewards if any
         // If the market haven't had any YTs since the last collect, the interest is 0
-        (uint256 collected, IPrincipalToken.TokenReward[] memory rewards) = data_.principalToken.collect(
+        (uint256 collected, IPrincipalToken.TokenReward[] memory rewards) = principalToken.collect(
             address(this),
             address(this)
         );
 
-        emit NapierCollectFuseEnter(VERSION, address(data_.principalToken), collected, rewards);
+        emit NapierCollectFuseEnter(VERSION, address(principalToken), collected, rewards);
     }
 }

--- a/contracts/fuses/napier/NapierCombineFuse.sol
+++ b/contracts/fuses/napier/NapierCombineFuse.sol
@@ -48,13 +48,13 @@ contract NapierCombineFuse is NapierUniversalRouterFuse {
     function enter(NapierCombineFuseEnterData calldata data_) external {
         IPrincipalToken pt = data_.principalToken;
 
-        if (!PlasmaVaultConfigLib.isSubstrateAsAssetGranted(MARKET_ID, address(data_.principalToken))) {
-            revert NapierFuseIInvalidMarketId();
+        if (!PlasmaVaultConfigLib.isSubstrateAsAssetGranted(MARKET_ID, address(pt))) {
+            revert NapierFuseIInvalidToken();
         }
 
         address yt = pt.i_yt();
         if (!PlasmaVaultConfigLib.isSubstrateAsAssetGranted(MARKET_ID, yt)) {
-            revert NapierFuseIInvalidMarketId();
+            revert NapierFuseIInvalidToken();
         }
         if (data_.principals == 0) {
             return;

--- a/contracts/fuses/napier/NapierRedeemFuse.sol
+++ b/contracts/fuses/napier/NapierRedeemFuse.sol
@@ -47,15 +47,16 @@ contract NapierRedeemFuse is NapierUniversalRouterFuse {
 
     /// @notice Redeems PTs for tokens after the maturity
     function enter(NapierRedeemFuseEnterData calldata data_) external {
-        if (!PlasmaVaultConfigLib.isSubstrateAsAssetGranted(MARKET_ID, address(data_.principalToken))) {
-            revert NapierFuseIInvalidMarketId();
+        IPrincipalToken pt = data_.principalToken;
+
+        if (!PlasmaVaultConfigLib.isSubstrateAsAssetGranted(MARKET_ID, address(pt))) {
+            revert NapierFuseIInvalidToken();
         }
 
         if (data_.principals == 0) {
             return;
         }
 
-        IPrincipalToken pt = data_.principalToken;
         address underlyingToken = pt.underlying();
         address asset = pt.i_asset();
 

--- a/contracts/fuses/napier/NapierSupplyFuse.sol
+++ b/contracts/fuses/napier/NapierSupplyFuse.sol
@@ -46,8 +46,10 @@ contract NapierSupplyFuse is NapierUniversalRouterFuse {
 
     /// @notice Supplies assets into Napier PT, minting PT + YT into the vault
     function enter(NapierSupplyFuseEnterData calldata data_) external {
-        if (!PlasmaVaultConfigLib.isSubstrateAsAssetGranted(MARKET_ID, address(data_.principalToken))) {
-            revert NapierFuseIInvalidMarketId();
+        IPrincipalToken pt = data_.principalToken;
+
+        if (!PlasmaVaultConfigLib.isSubstrateAsAssetGranted(MARKET_ID, address(pt))) {
+            revert NapierFuseIInvalidToken();
         }
         if (data_.amountIn == 0) {
             // NOTE: The following interaction relies on pre-transfer and CONTRACT_BALANCE.
@@ -55,8 +57,6 @@ contract NapierSupplyFuse is NapierUniversalRouterFuse {
             // Early return to keep behaviour predictable.
             return;
         }
-
-        IPrincipalToken pt = data_.principalToken;
 
         address underlying = pt.underlying(); // vault shares
         address asset = pt.i_asset();

--- a/test/fuses/napier/Napier.t.sol
+++ b/test/fuses/napier/Napier.t.sol
@@ -424,7 +424,7 @@ contract NapierSupplyFuseTest is Test {
         actions[0] = FuseAction({fuse: _supplyFuse, data: abi.encodeCall(NapierSupplyFuse.enter, data)});
 
         vm.prank(ALPHA);
-        vm.expectRevert(NapierUniversalRouterFuse.NapierFuseIInvalidMarketId.selector);
+        vm.expectRevert(NapierUniversalRouterFuse.NapierFuseIInvalidToken.selector);
         PlasmaVault(_plasmaVault).execute(actions);
     }
 
@@ -551,7 +551,7 @@ contract NapierSupplyFuseTest is Test {
         actions[0] = FuseAction({fuse: _redeemFuse, data: abi.encodeCall(NapierRedeemFuse.enter, data)});
 
         vm.prank(ALPHA);
-        vm.expectRevert(NapierUniversalRouterFuse.NapierFuseIInvalidMarketId.selector);
+        vm.expectRevert(NapierUniversalRouterFuse.NapierFuseIInvalidToken.selector);
         PlasmaVault(_plasmaVault).execute(actions);
     }
 
@@ -611,7 +611,7 @@ contract NapierSupplyFuseTest is Test {
         actions[0] = FuseAction({fuse: _collectFuse, data: abi.encodeCall(NapierCollectFuse.enter, data)});
 
         vm.prank(ALPHA);
-        vm.expectRevert(NapierUniversalRouterFuse.NapierFuseIInvalidMarketId.selector);
+        vm.expectRevert(NapierUniversalRouterFuse.NapierFuseIInvalidToken.selector);
         PlasmaVault(_plasmaVault).execute(actions);
     }
 
@@ -717,7 +717,7 @@ contract NapierSupplyFuseTest is Test {
         actions[0] = FuseAction({fuse: _combineFuse, data: abi.encodeCall(NapierCombineFuse.enter, data)});
 
         vm.prank(ALPHA);
-        vm.expectRevert(NapierUniversalRouterFuse.NapierFuseIInvalidMarketId.selector);
+        vm.expectRevert(NapierUniversalRouterFuse.NapierFuseIInvalidToken.selector);
         PlasmaVault(_plasmaVault).execute(actions);
     }
 


### PR DESCRIPTION
- **refactor(napier): rename error and improve code style**
- **test(napier): update revert error selector names**

## Issue

- resolve: #2 

## Why is this change needed?
Add Napier protocol integration to IPOR Fusion, enabling interactions with Napier's principal token system including supply, redeem, collect, combine, and swap operations.

## What would you like reviewers to focus on?
- Napier fuse implementations (NapierSupplyFuse, NapierRedeemFuse, NapierCollectFuse, NapierCombineFuse, NapierSwapPtFuse, NapierSwapYtFuse)
- NapierPriceFeed and NapierPriceFeedFactory implementations
- Test coverage for all new functionality

## Testing Verification
Comprehensive test suite added:
- `test/fuses/napier/Napier.t.sol` (938 lines)
- `test/price_oracle/price_feed/NapierPriceFeedFactoryTest.t.sol` (387 lines)

## Additional Notes
- Adds NAPIER market constant (1_000_014) in IporFusionMarkets.sol
- Includes external interfaces (IPrincipalToken, ITokiPoolToken, IV4Router, IUniversalRouter)
- Utility libraries for Napier protocol interactions (Actions, Commands, Constants)

