### PR TITLE
🔒(napier): add token validation for input and output tokens

### DIFF
--- a/contracts/fuses/napier/NapierCombineFuse.sol
+++ b/contracts/fuses/napier/NapierCombineFuse.sol
@@ -56,6 +56,11 @@ contract NapierCombineFuse is NapierUniversalRouterFuse {
         if (!PlasmaVaultConfigLib.isSubstrateAsAssetGranted(MARKET_ID, yt)) {
             revert NapierFuseIInvalidToken();
         }
+
+        if (!PlasmaVaultConfigLib.isSubstrateAsAssetGranted(MARKET_ID, data_.tokenOut)) {
+            revert NapierFuseIInvalidToken();
+        }
+
         if (data_.principals == 0) {
             return;
         }

--- a/contracts/fuses/napier/NapierRedeemFuse.sol
+++ b/contracts/fuses/napier/NapierRedeemFuse.sol
@@ -53,6 +53,10 @@ contract NapierRedeemFuse is NapierUniversalRouterFuse {
             revert NapierFuseIInvalidToken();
         }
 
+        if (!PlasmaVaultConfigLib.isSubstrateAsAssetGranted(MARKET_ID, data_.tokenOut)) {
+            revert NapierFuseIInvalidToken();
+        }
+
         if (data_.principals == 0) {
             return;
         }

--- a/contracts/fuses/napier/NapierSupplyFuse.sol
+++ b/contracts/fuses/napier/NapierSupplyFuse.sol
@@ -51,13 +51,17 @@ contract NapierSupplyFuse is NapierUniversalRouterFuse {
         if (!PlasmaVaultConfigLib.isSubstrateAsAssetGranted(MARKET_ID, address(pt))) {
             revert NapierFuseIInvalidToken();
         }
+
+        if (!PlasmaVaultConfigLib.isSubstrateAsAssetGranted(MARKET_ID, data_.tokenIn)) {
+            revert NapierFuseIInvalidToken();
+        }
+
         if (data_.amountIn == 0) {
             // NOTE: The following interaction relies on pre-transfer and CONTRACT_BALANCE.
             // Passing amountIn == 0 leaves the router free to sweep any residual balances (or to no-op silently).
             // Early return to keep behaviour predictable.
             return;
         }
-
         address underlying = pt.underlying(); // vault shares
         address asset = pt.i_asset();
 

--- a/contracts/fuses/napier/NapierSwapPtFuse.sol
+++ b/contracts/fuses/napier/NapierSwapPtFuse.sol
@@ -54,6 +54,16 @@ contract NapierSwapPtFuse is NapierUniversalRouterFuse {
         }
 
         PoolKey memory key = _getPoolKey(data_.pool);
+        address tokenIn = Currency.unwrap(key.currency0);
+        address tokenOut = Currency.unwrap(key.currency1);
+
+        if (!PlasmaVaultConfigLib.isSubstrateAsAssetGranted(MARKET_ID, tokenIn)) {
+            revert NapierFuseIInvalidToken();
+        }
+
+        if (!PlasmaVaultConfigLib.isSubstrateAsAssetGranted(MARKET_ID, tokenOut)) {
+            revert NapierFuseIInvalidToken();
+        }
 
         // Buy PT with the underlying token
         bytes memory commands = abi.encodePacked(bytes1(uint8(Commands.V4_SWAP)));
@@ -94,6 +104,16 @@ contract NapierSwapPtFuse is NapierUniversalRouterFuse {
         }
 
         PoolKey memory key = _getPoolKey(data_.pool);
+        address tokenIn = Currency.unwrap(key.currency1);
+        address tokenOut = Currency.unwrap(key.currency0);
+
+        if (!PlasmaVaultConfigLib.isSubstrateAsAssetGranted(MARKET_ID, tokenIn)) {
+            revert NapierFuseIInvalidToken();
+        }
+
+        if (!PlasmaVaultConfigLib.isSubstrateAsAssetGranted(MARKET_ID, tokenOut)) {
+            revert NapierFuseIInvalidToken();
+        }
 
         // Sell PT for the underlying token
         bytes memory commands = abi.encodePacked(bytes1(uint8(Commands.V4_SWAP)));


### PR DESCRIPTION
## Issue

- resolve: <!-- No issue linked in commits -->

## Why is this change needed?

- Adds substrate asset grant checks for tokenIn/tokenOut in all Napier fuse operations
- Prevents unauthorized tokens from being used in combine, redeem, supply, and swap operations

## What would you like reviewers to focus on?

- Token validation logic in fuse contracts
- Test coverage for revert scenarios

## Testing Verification

- Added tests verifying supply/redeem revert when token not granted
- Added tests verifying swap PT/YT enter/exit revert for invalid tokens
- Updated setup to grant underlying and base asset as substrates
- Added helper to selectively omit substrates for negative testing

## Additional Notes

Files modified:
- contracts/fuses/napier/NapierCombineFuse.sol
- contracts/fuses/napier/NapierRedeemFuse.sol
- contracts/fuses/napier/NapierSupplyFuse.sol
- contracts/fuses/napier/NapierSwapPtFuse.sol
- contracts/fuses/napier/NapierSwapYtFuse.sol
- test/fuses/napier/Napier.t.sol