### PR TITLE
🐞(oracle): Fix Napier Price Feed decimal handling

### DIFF
--- a/contracts/price_oracle/price_feed/NapierPriceFeed.sol
+++ b/contracts/price_oracle/price_feed/NapierPriceFeed.sol
@@ -60,9 +60,8 @@ contract NapierPriceFeed is IPriceFeed {
         QUOTE = quote;
     }
 
-    /// @notice PT prices are returned in 8 decimals to match Chainlink semantics
     function decimals() public pure override returns (uint8) {
-        return 8;
+        return 18;
     }
 
     /// @inheritdoc IPriceFeed
@@ -79,10 +78,9 @@ contract NapierPriceFeed is IPriceFeed {
     {
         (, int256 unitPrice, , , ) = TOKI_CHAINLINK_ORACLE.latestRoundData();
 
-        (uint256 assetPrice, uint256 priceDecimals) = IPriceOracleMiddleware(msg.sender).getAssetPrice(QUOTE);
+        (uint256 assetPrice, uint256 priceDecimals) = IPriceOracleMiddleware(PRICE_MIDDLEWARE).getAssetPrice(QUOTE);
 
-        uint256 scalingFactor = TOKI_CHAINLINK_ORACLE_DECIMALS + priceDecimals - decimals();
-        price = ((unitPrice.toUint256() * assetPrice) / 10 ** scalingFactor).toInt256();
+        price = ((unitPrice.toUint256() * assetPrice) / 10 ** priceDecimals).toInt256();
 
         if (price <= 0) {
             revert PriceOracleInvalidPrice();

--- a/contracts/price_oracle/price_feed/NapierPriceFeed.sol
+++ b/contracts/price_oracle/price_feed/NapierPriceFeed.sol
@@ -79,7 +79,7 @@ contract NapierPriceFeed is IPriceFeed {
     {
         (, int256 unitPrice, , , ) = TOKI_CHAINLINK_ORACLE.latestRoundData();
 
-        (uint256 assetPrice, uint256 priceDecimals) = IPriceOracleMiddleware(PRICE_MIDDLEWARE).getAssetPrice(QUOTE);
+        (uint256 assetPrice, uint256 priceDecimals) = IPriceOracleMiddleware(msg.sender).getAssetPrice(QUOTE);
 
         uint256 scalingFactor = TOKI_CHAINLINK_ORACLE_DECIMALS + priceDecimals - decimals();
         price = ((unitPrice.toUint256() * assetPrice) / 10 ** scalingFactor).toInt256();

--- a/test/price_oracle/price_feed/NapierPriceFeedFactoryTest.t.sol
+++ b/test/price_oracle/price_feed/NapierPriceFeedFactoryTest.t.sol
@@ -298,6 +298,7 @@ contract NapierPriceFeedFactoryTest is Test {
         assertEq(priceFeed.LIQUIDITY_TOKEN(), pool, "Liquidity token should match");
 
         // Verify price feed is functional
+        vm.prank(PRICE_MIDDLEWARE);
         (, int256 price, , uint256 timestamp, ) = priceFeed.latestRoundData();
         assertGt(price, 0, "Price should be positive");
         assertLt(price, 1e8, "Price should be less than 1e8");
@@ -320,6 +321,7 @@ contract NapierPriceFeedFactoryTest is Test {
         assertEq(priceFeed.LIQUIDITY_TOKEN(), pool, "Liquidity token should match");
 
         // Verify price feed is functional
+        vm.prank(PRICE_MIDDLEWARE);
         (, int256 price, , uint256 timestamp, ) = priceFeed.latestRoundData();
         assertGt(price, 0, "Price should be positive");
         assertLt(price, 1e8, "Price should be less than 1e8");

--- a/test/price_oracle/price_feed/NapierPriceFeedFactoryTest.t.sol
+++ b/test/price_oracle/price_feed/NapierPriceFeedFactoryTest.t.sol
@@ -296,12 +296,13 @@ contract NapierPriceFeedFactoryTest is Test {
         assertEq(priceFeed.QUOTE(), USDC, "Quote asset should match");
         assertEq(priceFeed.BASE(), principalToken, "Base asset should match");
         assertEq(priceFeed.LIQUIDITY_TOKEN(), pool, "Liquidity token should match");
+        assertEq(priceFeed.decimals(), 18, "Decimals should match");
 
         // Verify price feed is functional
         vm.prank(PRICE_MIDDLEWARE);
         (, int256 price, , uint256 timestamp, ) = priceFeed.latestRoundData();
         assertGt(price, 0, "Price should be positive");
-        assertLt(price, 1e8, "Price should be less than 1e8");
+        assertLt(price, 1e18, "Price should be less than 1e18");
         assertEq(timestamp, block.timestamp, "Timestamp should match block timestamp");
 
         console2.log("price", price);
@@ -319,12 +320,13 @@ contract NapierPriceFeedFactoryTest is Test {
         assertEq(priceFeed.QUOTE(), USDC, "Quote asset should match");
         assertEq(priceFeed.BASE(), principalToken, "Base asset should match");
         assertEq(priceFeed.LIQUIDITY_TOKEN(), pool, "Liquidity token should match");
+        assertEq(priceFeed.decimals(), 18, "Decimals should match");
 
         // Verify price feed is functional
         vm.prank(PRICE_MIDDLEWARE);
         (, int256 price, , uint256 timestamp, ) = priceFeed.latestRoundData();
         assertGt(price, 0, "Price should be positive");
-        assertLt(price, 1e8, "Price should be less than 1e8");
+        assertLt(price, 1e18, "Price should be less than 1e18");
         assertEq(timestamp, block.timestamp, "Timestamp should match block timestamp");
 
         console2.log("price", price);


### PR DESCRIPTION
## Issue

- Related to Napier Price Feed integration

## Why is this change needed?
Fix decimal handling in NapierPriceFeed to correctly use 18 decimals.

## What would you like reviewers to focus on?
- NapierPriceFeed.sol decimal conversion logic
- Test coverage adequacy

## Testing Verification
- Added NapierPriceFeedTest.t.sol (133 lines)
- Updated NapierPriceFeedFactoryTest.t.sol

## Additional Notes
None.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches NapierPriceFeed to 18 decimals and updates price scaling; tests adjusted to assert 18-decimal behavior.
> 
> - **Contracts**:
>   - `contracts/price_oracle/price_feed/NapierPriceFeed.sol`:
>     - Change `decimals()` from `8` to `18`.
>     - Simplify price computation in `latestRoundData()` to divide by `10 ** priceDecimals` (remove oracle-decimal scaling factor).
> - **Tests**:
>   - `test/price_oracle/price_feed/NapierPriceFeedFactoryTest.t.sol`:
>     - Assert `decimals() == 18` for created feeds.
>     - Update price bounds from `1e8` to `1e18` and invoke `latestRoundData()` under `PRICE_MIDDLEWARE` context.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53f14fbd0058ee5f0637d285dee636a2595f8bf1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->