### PR TITLE
♻️(napier): extract Permit2 utility library and add rewards validation

### DIFF
--- a/contracts/fuses/napier/NapierCollectFuse.sol
+++ b/contracts/fuses/napier/NapierCollectFuse.sol
@@ -51,6 +51,13 @@ contract NapierCollectFuse is NapierUniversalRouterFuse {
             address(this)
         );
 
+        // Post-validation of rewards tokens
+        for (uint256 i = 0; i < rewards.length; i++) {
+            if (!PlasmaVaultConfigLib.isSubstrateAsAssetGranted(MARKET_ID, address(rewards[i].token))) {
+                revert NapierFuseIInvalidToken();
+            }
+        }
+
         emit NapierCollectFuseEnter(VERSION, address(principalToken), collected, rewards);
     }
 }

--- a/contracts/fuses/napier/utils/LibPermit2.sol
+++ b/contracts/fuses/napier/utils/LibPermit2.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.10;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+import {IPermit2} from "../../balancer/ext/IPermit2.sol";
+
+library LibPermit2 {
+    using SafeERC20 for ERC20;
+
+    /// @notice Canonical Permit2 address
+    address private constant PERMIT2 = 0x000000000022D473030F116dDEE9F6B43aC78BA3;
+
+    /// @notice Sets up Permit2 approval for the router to pull tokens
+    /// @param token The token to approve
+    function setupPermit2Approval(address token, address spender) internal {
+        // Some tokens built with Solady requires an infinite amount to Permit2 approval
+        // We always approve an infinite amount to Permit2 to avoid the Permit2AllowanceIsFixedAtInfinity() error
+        ERC20(token).forceApprove(PERMIT2, type(uint256).max);
+        IPermit2(PERMIT2).approve(token, spender, type(uint160).max, uint48(block.timestamp));
+    }
+
+    /// @notice Resets Permit2 approval after execution
+    /// @param token The token to reset approval for
+    function resetPermit2Approval(address token, address spender) internal {
+        IPermit2(PERMIT2).approve(token, spender, 0, uint48(block.timestamp));
+    }
+}


### PR DESCRIPTION
## Issue

- resolve: N/A

## Why is this change needed?
- Extracts Permit2 signature handling into a reusable `LibPermit2` utility library
- Refactors `NapierSwapYtFuse` to reduce code duplication by leveraging the shared library
- Adds rewards validation to `NapierCollectFuse` for improved safety

## What would you like reviewers to focus on?
- Correctness of the extracted `LibPermit2` utility
- Integration with existing fuse contracts

## Testing Verification
- Existing test suite

## Additional Notes
- Part of the Napier integration feature branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Extracts Permit2 approval helpers into `LibPermit2` and adds reward token validation in `NapierCollectFuse`.
> 
> - **Contracts (Napier)**:
>   - **New utility**: `utils/LibPermit2.sol`
>     - Provides `setupPermit2Approval` and `resetPermit2Approval` using canonical Permit2.
>   - **`NapierSwapYtFuse.sol`**
>     - Replaces inline Permit2 logic with `LibPermit2` calls; removes local `PERMIT2` constant and private approval/reset functions.
>   - **`NapierCollectFuse.sol`**
>     - Adds post-collect validation ensuring each `rewards[i].token` is granted via `PlasmaVaultConfigLib`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f9a55dff352260632866fa7d2de28f3aebc25fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->